### PR TITLE
fix routing warning

### DIFF
--- a/src/App/Exercises/index.jsx
+++ b/src/App/Exercises/index.jsx
@@ -14,9 +14,9 @@ export function Exercises() {
     <Routes>
       <Route path="" element={<BlockLayout />}>
         <Route path="" element={<p>Wybierz kategorie</p>} />
-        <Route path="html-css" element={<HtmlCssExercises />} />
-        <Route path="js" element={<JsExercises />} />
-        <Route path="react" element={<ReactExercises />} />
+        <Route path="html-css/*" element={<HtmlCssExercises />} />
+        <Route path="js/*" element={<JsExercises />} />
+        <Route path="react/*" element={<ReactExercises />} />
       </Route>
       <Route path="html-css/*" element={<HtmlCssExerciseItem />} />
       <Route path="js/*" element={<JsExerciseItem />} />


### PR DESCRIPTION
W zakładce Ćwiczenia, przy przechodzenia do:
- [HTML & CSS - lista ćwiczeń](http://localhost:3000/exercises/html-css)
- [JS - lista ćwiczeń](http://localhost:3000/exercises/js)
- [React - lista ćwiczeń](http://localhost:3000/exercises/react)

Pojawia się Warning:
_utils.ts:900 You rendered descendant <Routes> (or called `useRoutes()`) at "/exercises/html-css" (under <Route path="html-css">) but the parent route path has no trailing "*". This means if you navigate deeper, the parent won't match anymore and therefore the child routes will never render.
Please change the parent <Route path="html-css"> to <Route path="html-css/*">._